### PR TITLE
Update MultipartConverter.java

### DIFF
--- a/src/main/java/com/tumblr/jumblr/request/MultipartConverter.java
+++ b/src/main/java/com/tumblr/jumblr/request/MultipartConverter.java
@@ -61,7 +61,7 @@ public class MultipartConverter {
 
     private void addResponsePiece(StringBuilder builder) {
         responsePieces.add(builder);
-        bodyLength += builder.toString().length();
+        bodyLength += builder.toString().getBytes().length;
     }
 
     private void computeBody(Map<String, ?> bodyMap) throws IOException {


### PR DESCRIPTION
Regarding Issue #12 - in case of using diacritics, like "ó" string length for it is 1, but number of bytes for it is more than 1. That is why we need to count number of bytes for a string, not string length
