### PR TITLE
Handle empty response bodies

### DIFF
--- a/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
+++ b/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
@@ -31,9 +31,14 @@ public class JumblrException extends RuntimeException {
 
         JsonParser parser = new JsonParser();
         try {
-            JsonObject object = parser.parse(body).getAsJsonObject();
-            this.extractMessage(object);
-            this.extractErrors(object);
+            final JsonElement element = parser.parse(body);
+            if (element.isJsonObject()) {
+                JsonObject object = element.getAsJsonObject();
+                this.extractMessage(object);
+                this.extractErrors(object);
+            } else {
+                this.message = body;
+            }
         } catch (JsonParseException ex) {
             this.message = body;
         }

--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -103,7 +103,7 @@ public class RequestBuilder {
         this.token = new Token(token, tokenSecret);
     }
 
-    private ResponseWrapper clear(Response response) {
+    /* package-visible for testing */ ResponseWrapper clear(Response response) {
         if (response.getCode() == 200 || response.getCode() == 201) {
             String json = response.getBody();
             try {
@@ -111,6 +111,9 @@ public class RequestBuilder {
                         registerTypeAdapter(JsonElement.class, new JsonElementDeserializer()).
                         create();
                 ResponseWrapper wrapper = gson.fromJson(json, ResponseWrapper.class);
+                if (wrapper == null) {
+                    throw new JumblrException(response);
+                }
                 wrapper.setClient(client);
                 return wrapper;
             } catch (JsonSyntaxException ex) {

--- a/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
+++ b/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
@@ -1,0 +1,34 @@
+package com.tumblr.jumblr.request;
+
+import com.tumblr.jumblr.exceptions.JumblrException;
+import com.tumblr.jumblr.responses.ResponseWrapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.scribe.model.Response;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestBuilderTest {
+    RequestBuilder rb;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        rb = new RequestBuilder(null);
+    }
+
+    @Test
+    public void testClearEmptyJson() {
+        Response r = mock(Response.class);
+        when(r.getCode()).thenReturn(200);
+        when(r.getBody()).thenReturn("");
+
+        thrown.expect(JumblrException.class);
+        ResponseWrapper got = rb.clear(r);
+    }
+}


### PR DESCRIPTION
I've seen a problem in production where RequestBuilder.clear NPEs
because gson.fromJson returns null, which it does when the passed-in
string (which is the response body) is empty.

I've added a unit test for this case. The test looks a bit silly
because it relies on mocking the response with a really implausible
one. There's nothing to stop you writing more mock responses with
nonsense values, which is the main shortcoming of this kind of test.
But in this case, this is just a regression test for a bug I've seen
in the wild, not just an invalid situation I've made up. Long-term,
it would be better to be able to plug in a fake server and test the
whole response decoding pipeline: since the API doesn't use SSL,
the 'server' could be sending any garbage down the line.

Armed with the test case, I've fixed the bug, and also found and
fixed a limitation of JumblrException: it couldn't handle an empty
response body either.
