### PR TITLE
Fixed: null pointer exception while fetching blogPosts

### DIFF
--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -73,7 +73,7 @@ public class RequestBuilder {
         OAuthRequest request = new OAuthRequest(Verb.GET, url);
         if (queryParams != null) {
             for (Map.Entry<String, ?> entry : queryParams.entrySet()) {
-                request.addQuerystringParameter(entry.getKey(), queryParams.get(entry.getValue()).toString());
+                request.addQuerystringParameter(entry.getKey(), queryParams.get(entry.getKey()).toString());
             }
         }
         return request;


### PR DESCRIPTION
Fixed issue with incorrect usage of getValue() in RequestBuilder.constructGet()
