### PR TITLE
PhotoPost not working with source URLs

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -78,6 +78,8 @@ public class PhotoPost extends Post {
         PhotoType type = photo.getType();
         if (postType != null && !postType.equals(type)) {
             throw new IllegalArgumentException("Photos must all be the same type (source or data)");
+        } else if (postType == PhotoType.SOURCE && pendingPhotos.size() > 0) {
+            throw new IllegalArgumentException("Only one source URL can be provided");
         }
         pendingPhotos = new ArrayList<Photo>();
         pendingPhotos.add(photo);
@@ -121,10 +123,12 @@ public class PhotoPost extends Post {
         details.put("link", link);
         details.put("caption", caption);
 
-        if (pendingPhotos != null) {
-            for (int i = 0; i < pendingPhotos.size(); i++) {
-                PhotoType type = pendingPhotos.get(0).getType();
-                if (type != null) {
+        if (pendingPhotos != null && pendingPhotos.size() > 0) {
+            PhotoType type = pendingPhotos.get(0).getType();
+            if(type == PhotoType.SOURCE) {
+                details.put("source", pendingPhotos.get(0).getDetail());
+            } else if(type == PhotoType.FILE) {
+                for (int i = 0; i < pendingPhotos.size(); i++) {
                     details.put(type.getPrefix() + "[" + i + "]", pendingPhotos.get(i).getDetail());
                 }
             }


### PR DESCRIPTION
The tumblr API accepts an Array for data parameter but not for source param. This results in 401 responses whenever attempting to create photo post with source.

http://www.tumblr.com/docs/en/api/v2#pphoto-posts
