### PR TITLE
Added Gradle section and bumped version number 0.0.6 => 0.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,19 @@ catch (JumblrException ex) {
 }
 ```
 
+## Gradle
+
+``` groovy
+compile 'com.tumblr:jumblr:0.0.11'
+```
+
 ## Maven
 
 ``` xml
 <dependency>
   <groupId>com.tumblr</groupId>
   <artifactId>jumblr</artifactId>
-  <version>0.0.6</version>
+  <version>0.0.11</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Added Gradle section to the README since that's the popular & suggested method for including dependencies now. Also bumped the version number in the readme from `0.0.6` => `0.0.11` to reflect what we have in Maven.