### PR TITLE
Fixes #60 - Return correct type String in Post's getType method

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -9,10 +9,6 @@ public class AnswerPost extends Post {
     private String question;
     private String answer;
 
-    public AnswerPost() {
-        type = PostType.ANSWER;
-    }
-
     /**
      * Get the asking URL
      * @return String URL
@@ -43,6 +39,11 @@ public class AnswerPost extends Post {
      */
     public String getAnswer() {
         return answer;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.ANSWER.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -5,7 +5,7 @@ package com.tumblr.jumblr.types;
  * @author jc
  */
 public class AnswerPost extends Post {
-    
+
     private String asking_name, asking_url;
     private String question;
     private String answer;

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -5,10 +5,13 @@ package com.tumblr.jumblr.types;
  * @author jc
  */
 public class AnswerPost extends Post {
-    private final PostType type = PostType.ANSWER;
     private String asking_name, asking_url;
     private String question;
     private String answer;
+
+    public AnswerPost() {
+        type = PostType.ANSWER;
+    }
 
     /**
      * Get the asking URL

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -5,6 +5,7 @@ package com.tumblr.jumblr.types;
  * @author jc
  */
 public class AnswerPost extends Post {
+    
     private String asking_name, asking_url;
     private String question;
     private String answer;

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -5,7 +5,7 @@ package com.tumblr.jumblr.types;
  * @author jc
  */
 public class AnswerPost extends Post {
-
+    private final PostType type = PostType.ANSWER;
     private String asking_name, asking_url;
     private String question;
     private String answer;

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -42,8 +42,8 @@ public class AnswerPost extends Post {
     }
 
     @Override
-    public String getType() {
-        return PostType.ANSWER.getValue();
+    public PostType getType() {
+        return PostType.ANSWER;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -135,7 +135,7 @@ public class AudioPost extends Post {
      */
     @Override
     public Map<String, Object> detail() {
-        Map<String, Object> details = super.detail();
+        final Map<String, Object> details = super.detail();
         details.put("caption", caption);
         details.put("data", data);
         details.put("external_url", external_url);

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -128,8 +128,8 @@ public class AudioPost extends Post {
     }
 
     @Override
-    public String getType() {
-        return PostType.AUDIO.getValue();
+    public PostType getType() {
+        return PostType.AUDIO;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -8,10 +8,12 @@ import java.util.Map;
  * @author jc
  */
 public class AudioPost extends Post {
+
     private String caption, player, audio_url;
     private Integer plays;
     private String album_art, artist, album, track_name;
     private Integer track_number, year;
+
     private File data;
     private String external_url;
 

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -8,7 +8,6 @@ import java.util.Map;
  * @author jc
  */
 public class AudioPost extends Post {
-    private final PostType type = PostType.AUDIO;
     private String caption, player, audio_url;
     private Integer plays;
     private String album_art, artist, album, track_name;
@@ -16,6 +15,10 @@ public class AudioPost extends Post {
 
     private File data;
     private String external_url;
+
+    public AudioPost() {
+        type = PostType.AUDIO;
+    }
 
     /**
      * Get the audio URL for this post

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * @author jc
  */
 public class AudioPost extends Post {
-
+    private final PostType type = PostType.AUDIO;
     private String caption, player, audio_url;
     private Integer plays;
     private String album_art, artist, album, track_name;
@@ -136,7 +136,7 @@ public class AudioPost extends Post {
     @Override
     public Map<String, Object> detail() {
         Map<String, Object> details = super.detail();
-        details.put("type", "audio");
+        details.put("type", type.getValue());
         details.put("caption", caption);
         details.put("data", data);
         details.put("external_url", external_url);

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -12,13 +12,8 @@ public class AudioPost extends Post {
     private Integer plays;
     private String album_art, artist, album, track_name;
     private Integer track_number, year;
-
     private File data;
     private String external_url;
-
-    public AudioPost() {
-        type = PostType.AUDIO;
-    }
 
     /**
      * Get the audio URL for this post
@@ -130,6 +125,11 @@ public class AudioPost extends Post {
      */
     public void setCaption(String caption) {
         this.caption = caption;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.AUDIO.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/AudioPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AudioPost.java
@@ -136,7 +136,6 @@ public class AudioPost extends Post {
     @Override
     public Map<String, Object> detail() {
         Map<String, Object> details = super.detail();
-        details.put("type", type.getValue());
         details.put("caption", caption);
         details.put("data", data);
         details.put("external_url", external_url);

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -8,6 +8,7 @@ import java.util.Map;
  * @author jc
  */
 public class ChatPost extends SafePost {
+
     private String title;
     private String body;
     private List<Dialogue> dialogue;

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -8,10 +8,13 @@ import java.util.Map;
  * @author jc
  */
 public class ChatPost extends SafePost {
-    private final PostType type = PostType.CHAT;
     private String title;
     private String body;
     private List<Dialogue> dialogue;
+
+    public ChatPost() {
+        type = PostType.CHAT;
+    }
 
     /**
      * Get the dialogues for this post

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -59,7 +59,7 @@ public class ChatPost extends SafePost {
      */
     @Override
     public Map<String, Object> detail() {
-        Map<String, Object> details = super.detail();
+        final Map<String, Object> details = super.detail();
         details.put("title", title);
         details.put("conversation", body);
         return details;

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * @author jc
  */
 public class ChatPost extends SafePost {
-
+    private final PostType type = PostType.CHAT;
     private String title;
     private String body;
     private List<Dialogue> dialogue;
@@ -62,7 +62,7 @@ public class ChatPost extends SafePost {
         Map<String, Object> details = super.detail();
         details.put("title", title);
         details.put("conversation", body);
-        details.put("type", "chat");
+        details.put("type", type.getValue());
         return details;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -62,7 +62,6 @@ public class ChatPost extends SafePost {
         Map<String, Object> details = super.detail();
         details.put("title", title);
         details.put("conversation", body);
-        details.put("type", type.getValue());
         return details;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -53,8 +53,8 @@ public class ChatPost extends SafePost {
     }
 
     @Override
-    public String getType() {
-        return PostType.CHAT.getValue();
+    public PostType getType() {
+        return PostType.CHAT;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/ChatPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/ChatPost.java
@@ -12,10 +12,6 @@ public class ChatPost extends SafePost {
     private String body;
     private List<Dialogue> dialogue;
 
-    public ChatPost() {
-        type = PostType.CHAT;
-    }
-
     /**
      * Get the dialogues for this post
      * @return an Array[Dialogue]
@@ -54,6 +50,11 @@ public class ChatPost extends SafePost {
      */
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.CHAT.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class LinkPost extends SafePost {
-
+    private final PostType type = PostType.LINK;
     private String title;
     private String url;
     private String description;
@@ -70,7 +70,7 @@ public class LinkPost extends SafePost {
         detail.put("title", title);
         detail.put("url", url);
         detail.put("description", description);
-        detail.put("type", "link");
+        detail.put("type", type.getValue());
         return detail;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -66,7 +66,7 @@ public class LinkPost extends SafePost {
      */
     @Override
     public Map<String, Object> detail() {
-        Map<String, Object> detail = super.detail();
+        final Map<String, Object> detail = super.detail();
         detail.put("title", title);
         detail.put("url", url);
         detail.put("description", description);

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -7,6 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class LinkPost extends SafePost {
+
     private String title;
     private String url;
     private String description;

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -7,10 +7,13 @@ import java.util.Map;
  * @author jc
  */
 public class LinkPost extends SafePost {
-    private final PostType type = PostType.LINK;
     private String title;
     private String url;
     private String description;
+
+    public LinkPost() {
+        type = PostType.LINK;
+    }
 
     /**
      * Get the title for this post

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -70,7 +70,6 @@ public class LinkPost extends SafePost {
         detail.put("title", title);
         detail.put("url", url);
         detail.put("description", description);
-        detail.put("type", type.getValue());
         return detail;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -11,10 +11,6 @@ public class LinkPost extends SafePost {
     private String url;
     private String description;
 
-    public LinkPost() {
-        type = PostType.LINK;
-    }
-
     /**
      * Get the title for this post
      * @return the title
@@ -61,6 +57,11 @@ public class LinkPost extends SafePost {
      */
     public void setLinkUrl(String url) {
         this.url = url;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.LINK.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/LinkPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/LinkPost.java
@@ -60,8 +60,8 @@ public class LinkPost extends SafePost {
     }
 
     @Override
-    public String getType() {
-        return PostType.LINK.getValue();
+    public PostType getType() {
+        return PostType.LINK;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -112,8 +112,8 @@ public class PhotoPost extends Post {
     }
 
     @Override
-    public String getType() {
-        return PostType.PHOTO.getValue();
+    public PostType getType() {
+        return PostType.PHOTO;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -21,10 +21,6 @@ public class PhotoPost extends Post {
     protected List<Photo> pendingPhotos;
     protected PhotoType postType = null;
 
-    public PhotoPost() {
-        type = PostType.PHOTO;
-    }
-
     /**
      * Get the Photo collection for this post
      * @return the photos

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * @author jc
  */
 public class PhotoPost extends Post {
-
+    private final PostType type = PostType.PHOTO;
     private String caption;
     private Integer width, height;
 
@@ -119,7 +119,7 @@ public class PhotoPost extends Post {
     @Override
     public Map<String, Object> detail() {
         Map<String, Object> details = super.detail();
-        details.put("type", "photo");
+        details.put("type", type.getValue());
         details.put("link", link);
         details.put("caption", caption);
 

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -111,6 +111,11 @@ public class PhotoPost extends Post {
         this.link = linkUrl;
     }
 
+    @Override
+    public String getType() {
+        return PostType.PHOTO.getValue();
+    }
+
     /**
      * Get the detail for this post (and the base detail)
      * @return the details

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -119,7 +119,6 @@ public class PhotoPost extends Post {
     @Override
     public Map<String, Object> detail() {
         Map<String, Object> details = super.detail();
-        details.put("type", type.getValue());
         details.put("link", link);
         details.put("caption", caption);
 

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -11,7 +11,6 @@ import java.util.Map;
  * @author jc
  */
 public class PhotoPost extends Post {
-    private final PostType type = PostType.PHOTO;
     private String caption;
     private Integer width, height;
 
@@ -21,6 +20,10 @@ public class PhotoPost extends Post {
 
     protected List<Photo> pendingPhotos;
     protected PhotoType postType = null;
+
+    public PhotoPost() {
+        type = PostType.PHOTO;
+    }
 
     /**
      * Get the Photo collection for this post

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -118,7 +118,7 @@ public class PhotoPost extends Post {
      */
     @Override
     public Map<String, Object> detail() {
-        Map<String, Object> details = super.detail();
+        final Map<String, Object> details = super.detail();
         details.put("link", link);
         details.put("caption", caption);
 

--- a/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PhotoPost.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * @author jc
  */
 public class PhotoPost extends Post {
+
     private String caption;
     private Integer width, height;
 

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -188,7 +188,7 @@ public class Post extends Resource {
     public Long getLikedTimestamp() { return liked_timestamp; }
 
     /**
-     * Get the type of this post String value
+     * Get the type of this post
      * @return type as String
      */
     public String getType() {

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -381,12 +381,13 @@ public class Post extends Resource {
      * @return the detail
      */
     protected Map<String, Object> detail() {
-        Map<String, Object> map = new HashMap<String, Object>();
+        final Map<String, Object> map = new HashMap<String, Object>();
         map.put("state", state);
         map.put("tags", getTagString());
         map.put("format", format);
         map.put("slug", slug);
         map.put("date", date);
+        map.put("type", type.getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -16,6 +16,32 @@ import org.apache.commons.lang3.StringUtils;
  * @author jc
  */
 public class Post extends Resource {
+    /**
+     * Enum of valid Post types
+     * @author kevintcoughlin
+     */
+    public enum PostType {
+        TEXT("text"),
+        ANSWER("answer"),
+        CHAT("chat"),
+        LINK("link"),
+        PHOTO("photo"),
+        PHOTOSET("photoset"),
+        POSTCARD("postcard"),
+        QUOTE("quote"),
+        VIDEO("video"),
+        UNKNOWN("unknown");
+
+        private final String mType;
+
+        PostType(final String type) {
+            this.mType = type;
+        }
+
+        public String getType() {
+            return this.mType;
+        }
+    }
 
     private Long id;
     private String author;

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -65,9 +65,6 @@ public class Post extends Resource {
     private Long note_count;
     private List<Note> notes;
 
-    public Post() {
-    }
-
     /**
      * Get the id of the author of the post
      * @return possibly null author id

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -28,7 +28,8 @@ public class Post extends Resource {
         CHAT("chat"),
         AUDIO("audio"),
         VIDEO("video"),
-        ANSWER("answer");
+        ANSWER("answer"),
+        UNKNOWN("unknown");
 
         private final String mType;
 
@@ -41,12 +42,12 @@ public class Post extends Resource {
         }
     }
 
+    protected PostType type = PostType.UNKNOWN;
     private Long id;
     private String author;
     private String reblog_key;
     private String blog_name;
     private String post_url, short_url;
-    private PostType type;
     private Long timestamp;
     private Long liked_timestamp;
     private String state;

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -16,9 +16,9 @@ import org.apache.commons.lang3.StringUtils;
  * @author jc
  */
 public class Post extends Resource {
+
     /**
-     * Enum of valid Post types
-     * @author kevintcoughlin
+     * Enum of valid post types.
      */
     public enum PostType {
         TEXT("text"),
@@ -66,7 +66,6 @@ public class Post extends Resource {
     private List<Note> notes;
 
     public Post() {
-        this.type = PostType.UNKNOWN;
     }
 
     /**
@@ -191,8 +190,8 @@ public class Post extends Resource {
      * Get the type of this post
      * @return type as String
      */
-    public String getType() {
-        return PostType.UNKNOWN.getValue();
+    public PostType getType() {
+        return PostType.UNKNOWN;
     }
 
     /**
@@ -390,7 +389,7 @@ public class Post extends Resource {
         map.put("format", format);
         map.put("slug", slug);
         map.put("date", date);
-        map.put("type", getType());
+        map.put("type", getType().getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -22,16 +22,13 @@ public class Post extends Resource {
      */
     public enum PostType {
         TEXT("text"),
-        ANSWER("answer"),
-        CHAT("chat"),
-        LINK("link"),
         PHOTO("photo"),
-        PHOTOSET("photoset"),
-        POSTCARD("postcard"),
         QUOTE("quote"),
+        LINK("link"),
+        CHAT("chat"),
+        AUDIO("audio"),
         VIDEO("video"),
-        UNKNOWN("unknown"),
-        AUDIO("audio");
+        ANSWER("answer");
 
         private final String mType;
 

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -387,7 +387,7 @@ public class Post extends Resource {
         map.put("format", format);
         map.put("slug", slug);
         map.put("date", date);
-        map.put("type", type.getValue());
+        map.put("type", getType());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -29,6 +29,7 @@ public class Post extends Resource {
         AUDIO("audio"),
         VIDEO("video"),
         ANSWER("answer"),
+        POSTCARD("postcard"),
         UNKNOWN("unknown");
 
         private final String mType;
@@ -42,7 +43,7 @@ public class Post extends Resource {
         }
     }
 
-    protected PostType type = PostType.UNKNOWN;
+    protected PostType type;
     private Long id;
     private String author;
     private String reblog_key;
@@ -63,6 +64,10 @@ public class Post extends Resource {
     private String reblogged_from_name;
     private Long note_count;
     private List<Note> notes;
+
+    public Post() {
+        this.type = PostType.UNKNOWN;
+    }
 
     /**
      * Get the id of the author of the post
@@ -187,7 +192,7 @@ public class Post extends Resource {
      * @return type as String
      */
     public String getType() {
-        return type.getValue();
+        return PostType.UNKNOWN.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -30,7 +30,8 @@ public class Post extends Resource {
         POSTCARD("postcard"),
         QUOTE("quote"),
         VIDEO("video"),
-        UNKNOWN("unknown");
+        UNKNOWN("unknown"),
+        AUDIO("audio");
 
         private final String mType;
 
@@ -38,7 +39,7 @@ public class Post extends Resource {
             this.mType = type;
         }
 
-        public String getType() {
+        public String getValue() {
             return this.mType;
         }
     }
@@ -48,7 +49,7 @@ public class Post extends Resource {
     private String reblog_key;
     private String blog_name;
     private String post_url, short_url;
-    private String type;
+    private PostType type;
     private Long timestamp;
     private Long liked_timestamp;
     private String state;
@@ -184,11 +185,11 @@ public class Post extends Resource {
     public Long getLikedTimestamp() { return liked_timestamp; }
 
     /**
-     * Get the type of this post
+     * Get the type of this post String value
      * @return type as String
      */
     public String getType() {
-        return type;
+        return type.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/PostcardPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PostcardPost.java
@@ -61,8 +61,8 @@ public class PostcardPost extends SafePost {
     }
 
     @Override
-    public String getType() {
-        return PostType.POSTCARD.getValue();
+    public PostType getType() {
+        return PostType.POSTCARD;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/PostcardPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/PostcardPost.java
@@ -60,17 +60,21 @@ public class PostcardPost extends SafePost {
         this.body = body;
     }
 
+    @Override
+    public String getType() {
+        return PostType.POSTCARD.getValue();
+    }
+
     /**
      * Get the details for this post (and the base details)
      * @return the details
      */
     @Override
     protected Map<String, Object> detail() {
-        Map<String, Object> map = super.detail();
+        final Map<String, Object> map = super.detail();
         map.put("body", body);
         map.put("asking_name", asking_name);
         map.put("asking_url", asking_url);
-        map.put("type", "postcard");
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class QuotePost extends SafePost {
-
+    private final PostType type = PostType.QUOTE;
     private String text;
     private String source;
 
@@ -52,7 +52,7 @@ public class QuotePost extends SafePost {
         Map<String, Object> map = super.detail();
         map.put("quote", this.text);
         map.put("source", this.source);
-        map.put("type", "quote");
+        map.put("type", type.getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -43,8 +43,8 @@ public class QuotePost extends SafePost {
     }
 
     @Override
-    public String getType() {
-        return PostType.QUOTE.getValue();
+    public PostType getType() {
+        return PostType.QUOTE;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -10,10 +10,6 @@ public class QuotePost extends SafePost {
     private String text;
     private String source;
 
-    public QuotePost() {
-        type = PostType.QUOTE;
-    }
-
     /**
      * Get the text of this post
      * @return the text
@@ -44,6 +40,11 @@ public class QuotePost extends SafePost {
      */
     public void setSource(String source) {
         this.source = source;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.QUOTE.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -52,7 +52,6 @@ public class QuotePost extends SafePost {
         Map<String, Object> map = super.detail();
         map.put("quote", this.text);
         map.put("source", this.source);
-        map.put("type", type.getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -7,6 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class QuotePost extends SafePost {
+
     private String text;
     private String source;
 

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -7,9 +7,12 @@ import java.util.Map;
  * @author jc
  */
 public class QuotePost extends SafePost {
-    private final PostType type = PostType.QUOTE;
     private String text;
     private String source;
+
+    public QuotePost() {
+        type = PostType.QUOTE;
+    }
 
     /**
      * Get the text of this post

--- a/src/main/java/com/tumblr/jumblr/types/QuotePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/QuotePost.java
@@ -49,7 +49,7 @@ public class QuotePost extends SafePost {
      */
     @Override
     protected Map<String, Object> detail() {
-        Map<String, Object> map = super.detail();
+        final Map<String, Object> map = super.detail();
         map.put("quote", this.text);
         map.put("source", this.source);
         return map;

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -7,6 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class TextPost extends SafePost {
+
     private String title;
     private String body;
 

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -43,8 +43,8 @@ public class TextPost extends SafePost {
     }
 
     @Override
-    public String getType() {
-        return PostType.TEXT.getValue();
+    public PostType getType() {
+        return PostType.TEXT;
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -52,7 +52,6 @@ public class TextPost extends SafePost {
         final Map<String, Object> map = super.detail();
         map.put("title", this.title);
         map.put("body", this.body);
-        map.put("type", this.type.getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -10,10 +10,6 @@ public class TextPost extends SafePost {
     private String title;
     private String body;
 
-    public TextPost() {
-        type = PostType.TEXT;
-    }
-
     /**
      * Get the title of this post
      * @return the title
@@ -44,6 +40,11 @@ public class TextPost extends SafePost {
      */
     public void setBody(String body) {
         this.body = body;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.TEXT.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * @author jc
  */
 public class TextPost extends SafePost {
-
+    private final PostType type = PostType.TEXT;
     private String title;
     private String body;
 
@@ -49,10 +49,10 @@ public class TextPost extends SafePost {
      */
     @Override
     protected Map<String, Object> detail() {
-        Map<String, Object> map = super.detail();
+        final Map<String, Object> map = super.detail();
         map.put("title", this.title);
         map.put("body", this.body);
-        map.put("type", "text");
+        map.put("type", this.type.getValue());
         return map;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/TextPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/TextPost.java
@@ -7,9 +7,12 @@ import java.util.Map;
  * @author jc
  */
 public class TextPost extends SafePost {
-    private final PostType type = PostType.TEXT;
     private String title;
     private String body;
+
+    public TextPost() {
+        type = PostType.TEXT;
+    }
 
     /**
      * Get the title of this post

--- a/src/main/java/com/tumblr/jumblr/types/UnknownTypePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/UnknownTypePost.java
@@ -6,5 +6,7 @@ package com.tumblr.jumblr.types;
  * @author john
  */
 public class UnknownTypePost extends SafePost {
-
+    public UnknownTypePost() {
+        type = PostType.UNKNOWN;
+    }
 }

--- a/src/main/java/com/tumblr/jumblr/types/UnknownTypePost.java
+++ b/src/main/java/com/tumblr/jumblr/types/UnknownTypePost.java
@@ -6,7 +6,5 @@ package com.tumblr.jumblr.types;
  * @author john
  */
 public class UnknownTypePost extends SafePost {
-    public UnknownTypePost() {
-        type = PostType.UNKNOWN;
-    }
+
 }

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -17,10 +17,6 @@ public class VideoPost extends Post {
     private int thumbnail_width;
     private int thumbnail_height;
 
-    public VideoPost() {
-        type = PostType.VIDEO;
-    }
-
     /**
      * Get the permalink URL for this video
      */
@@ -98,6 +94,11 @@ public class VideoPost extends Post {
      */
     public void setCaption(String caption) {
         this.caption = caption;
+    }
+
+    @Override
+    public String getType() {
+        return PostType.VIDEO.getValue();
     }
 
     /**

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -9,6 +9,7 @@ import java.util.Map;
  * @author jc
  */
 public class VideoPost extends Post {
+
     private List<Video> player;
     private String caption;
     private String embed, permalink_url;

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * @author jc
  */
 public class VideoPost extends Post {
-
+    private final PostType type = PostType.VIDEO;
     private List<Video> player;
     private String caption;
     private String embed, permalink_url;
@@ -107,7 +107,7 @@ public class VideoPost extends Post {
         details.put("caption", caption);
         details.put("embed", embed);
         details.put("data", data);
-        details.put("type", "video");
+        details.put("type", type.getValue());
         return details;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -9,7 +9,6 @@ import java.util.Map;
  * @author jc
  */
 public class VideoPost extends Post {
-    private final PostType type = PostType.VIDEO;
     private List<Video> player;
     private String caption;
     private String embed, permalink_url;
@@ -17,6 +16,10 @@ public class VideoPost extends Post {
     private String thumbnail_url;
     private int thumbnail_width;
     private int thumbnail_height;
+
+    public VideoPost() {
+        type = PostType.VIDEO;
+    }
 
     /**
      * Get the permalink URL for this video
@@ -103,11 +106,10 @@ public class VideoPost extends Post {
      */
     @Override
     public Map<String, Object> detail() {
-        Map<String, Object> details = super.detail();
+        final Map<String, Object> details = super.detail();
         details.put("caption", caption);
         details.put("embed", embed);
         details.put("data", data);
-        details.put("type", type.getValue());
         return details;
     }
 

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -97,8 +97,8 @@ public class VideoPost extends Post {
     }
 
     @Override
-    public String getType() {
-        return PostType.VIDEO.getValue();
+    public PostType getType() {
+        return PostType.VIDEO;
     }
 
     /**


### PR DESCRIPTION
This PR fixes #60 - "Jumblr getType on a Post returns null".

Posts now return their correct String value for type when `getType()` is called. This PR adds an enum of PostTypes for all supported post types and an `unknown` fallback. Previously the type was hardcoded in the detail HashMap instead of the type member variable itself. Now the detail bundle pulls its type from `getType` in the base `Post.class`. Also marked some local vars as `final`.

Test coverage passes but could use some extra eyes on this if available.