### PR TITLE
Add missing Note fields: reply_text and added_text

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/Note.java
+++ b/src/main/java/com/tumblr/jumblr/types/Note.java
@@ -56,4 +56,24 @@ public class Note {
         return post_id;
     }
 
+    /**
+     * Returns the added text of the reblog. This only exists if this is a reblog; otherwise
+     * this returns null.
+     *
+     * @return the added text of the reblog.
+     */
+    public String getAddedText() {
+        return added_text;
+    }
+
+    /**
+     * Returns the reply text of the reply. This only exists if this is a reply; otherwise
+     * this returns null.
+     *
+     * @return the reply text of the reply.
+     */
+    public String getReplyText() {
+        return reply_text;
+    }
+
 }

--- a/src/main/java/com/tumblr/jumblr/types/Note.java
+++ b/src/main/java/com/tumblr/jumblr/types/Note.java
@@ -7,6 +7,8 @@ public class Note {
     private String blog_url;
     private String type;
     private Long post_id;
+    private String reply_text;
+    private String added_text;
 
     /**
      * Get the timestamp of this note


### PR DESCRIPTION
Fixes #59: This PR adds the missing `Note` fields: `reply_text` & `added_text`. Now when Gson deserializes Post JSON w/ notes metadata it will include the fields if they are present.

