### PR TITLE
Allow VideoPost to return the actual video_url

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -12,7 +12,7 @@ public class VideoPost extends Post {
 
     private List<Video> player;
     private String caption;
-    private String embed, permalink_url;
+    private String embed, permalink_url, video_url;
     private File data;
     private String thumbnail_url;
     private int thumbnail_width;
@@ -23,6 +23,13 @@ public class VideoPost extends Post {
      */
     public String getPermalinkUrl() {
         return permalink_url;
+    }
+
+    /**
+     * Get the direct URL for this video
+     */
+    public String getVideoUrl() {
+        return video_url;
     }
 
     /**


### PR DESCRIPTION
The VideoPost class is missing the definition and return of the field video_url. This adds this field as a valid return for this class.