### PR TITLE
Return number of Draft and Queued Posts for a blog

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/Blog.java
+++ b/src/main/java/com/tumblr/jumblr/types/Blog.java
@@ -12,7 +12,7 @@ public class Blog extends Resource {
     private String name;
     private String title;
     private String description;
-    private int posts, likes, followers;
+    private int posts, likes, followers, drafts, queue;
     private Long updated;
     private boolean ask, ask_anon;
 
@@ -54,6 +54,22 @@ public class Blog extends Resource {
      */
     public Integer getLikeCount() {
         return this.likes;
+    }
+
+    /**
+     * Get the number of drafts for this blog
+     * @return int the number of drafts
+     */
+    public Integer getDraftCount() {
+        return this.drafts;
+    }
+
+    /**
+     * Get the number of Queued Posts for this blog
+     * @return int the number of Queued Posts
+     */
+    public Integer getQueuedCount() {
+        return this.queue;
     }
 
     /**


### PR DESCRIPTION
While the Tumblr interface returns the Total Number of Draft Posts and the total number of Queued Posts for a blog, the Jumblr interface did not include them. Thus calling applications were forced to "count" them directly instead; a resource wasting process. This change returns these two counts in the Blog class.