### PR TITLE
Add the missing reblog info fields to Post

### DIFF
--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -34,8 +34,9 @@ public class Post extends Resource {
     private String source_title;
     private Boolean liked;
     private String slug;
-    private Long reblogged_from_id;
-    private String reblogged_from_name;
+    private Long reblogged_from_id, reblogged_root_id;
+    private String reblogged_from_url, reblogged_from_name, reblogged_from_title;
+    private String reblogged_root_url, reblogged_root_name, reblogged_root_title;
     private Long note_count;
     private List<Note> notes;
 
@@ -211,6 +212,48 @@ public class Post extends Resource {
      */
     public String getRebloggedFromName() {
         return reblogged_from_name;
+    }
+
+    /**
+     * @return the url for the post that this post reblogged.
+     */
+    public String getRebloggedFromUrl() {
+        return reblogged_from_url;
+    }
+
+    /**
+     * @return the title for the post that this post reblogged.
+     */
+    public String getRebloggedFromTitle() {
+        return reblogged_from_title;
+    }
+
+    /**
+     * @return the root id for the post that this post reblogged.
+     */
+    public Long getRebloggedRootId() {
+        return reblogged_root_id;
+    }
+
+    /**
+     * @return the root url for the post that this post reblogged.
+     */
+    public String getRebloggedRootUrl() {
+        return reblogged_root_url;
+    }
+
+    /**
+     * @return the root name for the post that this post reblogged.
+     */
+    public String getRebloggedRootName() {
+        return reblogged_root_name;
+    }
+
+    /**
+     * @return the root title for the post that this post reblogged.
+     */
+    public String getRebloggedRootTitle() {
+        return reblogged_root_title;
     }
 
     /**


### PR DESCRIPTION
### Overview
This adds the missing `reblog_*` fields to `Post.java` brought up in #76.

### Concerns
- I'm unsure about the JavaDoc accuracy for the new Getters. Also this documentation seems to be missing on https://www.tumblr.com/docs/en/api/v2 cc: @ceyko
- Add tests? Our testing solution is lacking. I can follow the style that exists in `TextPost` for example, but I'd like to just inflate a flat JSON file down the road or something.

**Example existing test:**
```java
        Map<String, Object> flat = new HashMap<String, Object>();
        flat.put("type", "text");
        flat.put("title", title);
        flat.put("body", body);
        flat.put("note_count", noteCount);
        flat.put("reblogged_from_id", rebloggedFromId);
        flat.put("reblogged_from_name", rebloggedFromName);
        Gson gson = new GsonBuilder().registerTypeAdapter(Post.class, new PostDeserializer()).create();
        post = (TextPost) gson.fromJson(flatSerialize(flat), Post.class);
```