### PR TITLE
Update to com.github.scribejava

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
   - oraclejdk7
-  - openjdk6
   - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.scribe</groupId>
-            <artifactId>scribe</artifactId>
-            <version>1.3.3</version>
+            <groupId>com.ning</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>1.9.31</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-apis</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/tumblr/jumblr/JumblrClient.java
+++ b/src/main/java/com/tumblr/jumblr/JumblrClient.java
@@ -4,7 +4,7 @@ import com.tumblr.jumblr.request.RequestBuilder;
 import com.tumblr.jumblr.types.Blog;
 import com.tumblr.jumblr.types.Post;
 import com.tumblr.jumblr.types.User;
-import org.scribe.model.Token;
+import com.github.scribejava.core.model.Token;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
+++ b/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
@@ -4,7 +4,7 @@ import com.google.gson.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.scribe.model.Response;
+import com.github.scribejava.core.model.Response;
 
 
 /**

--- a/src/main/java/com/tumblr/jumblr/request/MultipartConverter.java
+++ b/src/main/java/com/tumblr/jumblr/request/MultipartConverter.java
@@ -9,7 +9,7 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.scribe.model.OAuthRequest;
+import com.github.scribejava.core.model.OAuthRequest;
 
 /**
  * Convert a OAuthRequest POST into a multi-part OAuthRequest
@@ -30,7 +30,7 @@ public class MultipartConverter {
     }
 
     public OAuthRequest getRequest() {
-        OAuthRequest request = new OAuthRequest(originalRequest.getVerb(), originalRequest.getUrl());
+        OAuthRequest request = new OAuthRequest(originalRequest.getVerb(), originalRequest.getUrl(), originalRequest.getService());
         request.addHeader("Authorization", originalRequest.getHeaders().get("Authorization"));
         request.addHeader("Content-Type", "multipart/form-data, boundary=" + boundary);
         request.addHeader("Content-length", bodyLength.toString());

--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -181,8 +181,12 @@ public class RequestBuilder {
         throw new JumblrException(response);
     }
 
-    /* package-visible for testing */ Token clearXAuth(Response response) {
-        if (response.getCode() == 200 || response.getCode() == 201) {
+    private Token clearXAuth(Response response) {
+        return clearXAuth(response, response.getCode());
+    }
+
+    /* package-visible for testing */ Token clearXAuth(Response response, int code) {
+        if (code == 200 || code == 201) {
             return parseXAuthResponse(response);
         } else {
             throw new JumblrException(response);

--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -12,13 +12,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.Map;
-import org.scribe.builder.ServiceBuilder;
-import org.scribe.builder.api.TumblrApi;
-import org.scribe.model.OAuthRequest;
-import org.scribe.model.Response;
-import org.scribe.model.Token;
-import org.scribe.model.Verb;
-import org.scribe.oauth.OAuthService;
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.apis.TumblrApi;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Token;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuthService;
 
 /**
  * Where requests are made from
@@ -80,7 +80,7 @@ public class RequestBuilder {
 
     // Construct an XAuth request
     private OAuthRequest constructXAuthPost(String email, String password) {
-        OAuthRequest request = new OAuthRequest(Verb.POST, xauthEndpoint);
+        OAuthRequest request = new OAuthRequest(Verb.POST, xauthEndpoint, service);
         request.addBodyParameter("x_auth_username", email);
         request.addBodyParameter("x_auth_password", password);
         request.addBodyParameter("x_auth_mode", "client_auth");
@@ -95,7 +95,7 @@ public class RequestBuilder {
 
     public OAuthRequest constructGet(String path, Map<String, ?> queryParams) {
         String url = "https://" + hostname + "/v2" + path;
-        OAuthRequest request = new OAuthRequest(Verb.GET, url);
+        OAuthRequest request = new OAuthRequest(Verb.GET, url, service);
         if (queryParams != null) {
             for (Map.Entry<String, ?> entry : queryParams.entrySet()) {
                 request.addQuerystringParameter(entry.getKey(), entry.getValue().toString());
@@ -108,7 +108,7 @@ public class RequestBuilder {
 
     private OAuthRequest constructPost(String path, Map<String, ?> bodyMap) {
         String url = "https://" + hostname + "/v2" + path;
-        OAuthRequest request = new OAuthRequest(Verb.POST, url);
+        OAuthRequest request = new OAuthRequest(Verb.POST, url, service);
 
         for (Map.Entry<String, ?> entry : bodyMap.entrySet()) {
         	String key = entry.getKey();

--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -136,8 +136,12 @@ public class RequestBuilder {
         this.token = token;
     }
 
-    /* package-visible for testing */ ResponseWrapper clear(Response response) {
-        if (response.getCode() == 200 || response.getCode() == 201) {
+    private ResponseWrapper clear(Response response) {
+        return clear(response, response.getCode());
+    }
+
+    /* package-visible for testing */ ResponseWrapper clear(Response response, int code) {
+        if (code == 200 || code == 201) {
             String json = response.getBody();
             try {
                 Gson gson = new GsonBuilder().

--- a/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
+++ b/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
@@ -53,20 +53,18 @@ public class RequestBuilderTest {
     @Test
     public void testXauthForbidden() {
         Response r = mock(Response.class);
-        when(r.getCode()).thenReturn(403);
         when(r.getBody()).thenReturn("");
 
         thrown.expect(JumblrException.class);
-        rb.clearXAuth(r);
+        rb.clearXAuth(r, 403);
     }
 
     @Test
     public void testXauthSuccess() {
         Response r = mock(Response.class);
-        when(r.getCode()).thenReturn(200);
         when(r.getBody()).thenReturn("oauth_token=valueForToken&oauth_token_secret=valueForSecret");
 
-        Token token = rb.clearXAuth(r);
+        Token token = rb.clearXAuth(r, 200);
         assertEquals(token.getToken(), "valueForToken");
         assertEquals(token.getSecret(), "valueForSecret");
     }
@@ -74,10 +72,9 @@ public class RequestBuilderTest {
     @Test
     public void testXauthSuccessWithExtra() {
         Response r = mock(Response.class);
-        when(r.getCode()).thenReturn(201);
         when(r.getBody()).thenReturn("oauth_token=valueForToken&oauth_token_secret=valueForSecret&other=paramisokay");
 
-        Token token = rb.clearXAuth(r);
+        Token token = rb.clearXAuth(r, 201);
         assertEquals(token.getToken(), "valueForToken");
         assertEquals(token.getSecret(), "valueForSecret");
     }
@@ -85,11 +82,10 @@ public class RequestBuilderTest {
     @Test
     public void testXauthBadResponseGoodCode() {
         Response r = mock(Response.class);
-        when(r.getCode()).thenReturn(200);
         when(r.getBody()).thenReturn("");
 
         thrown.expect(JumblrException.class);
-        rb.clearXAuth(r);
+        rb.clearXAuth(r, 200);
     }
 
 }

--- a/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
+++ b/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
@@ -31,11 +31,10 @@ public class RequestBuilderTest {
     @Test
     public void testClearEmptyJson() {
         Response r = mock(Response.class);
-        when(r.getCode()).thenReturn(200);
         when(r.getBody()).thenReturn("");
 
         thrown.expect(JumblrException.class);
-        ResponseWrapper got = rb.clear(r);
+        ResponseWrapper got = rb.clear(r, 200);
     }
 
     @Test

--- a/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
+++ b/src/test/java/com/tumblr/jumblr/request/RequestBuilderTest.java
@@ -12,9 +12,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.scribe.model.OAuthRequest;
-import org.scribe.model.Response;
-import org.scribe.model.Token;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Token;
 
 public class RequestBuilderTest {
 


### PR DESCRIPTION
This resolves #82, which turned out to be more complicated than I expected. Here are the changes:

* Update `org.scribe` to `com.github.scribejava`, the version was updated from `1.3.3` to `2.0.1`
* Update the corresponding imports.
* Add `async-http-client`. Either gson or scribe needs this, and for some reason neither of them includes it.
* `Response.getCode()` is now `final`, so it is no longer possible to mock it with Mockito (see https://github.com/scribejava/scribejava/issues/313). Luckily, only `private` methods were being tested, so the solution was to add a helper method that took a `code` as an additional argument, and then `RequestBuilderTest` would test that method instead.
* The tests fail on `openjdk6` because scribejava targets Java 7 and up: https://github.com/scribejava/scribejava/blob/master/pom.xml#L111-L112