### PR TITLE
Avatar requests set no-follow-redirects locally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.scribe</groupId>
             <artifactId>scribe</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -10,7 +10,6 @@ import com.tumblr.jumblr.responses.JsonElementDeserializer;
 import com.tumblr.jumblr.responses.ResponseWrapper;
 import java.io.File;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.util.Map;
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.builder.api.TumblrApi;
@@ -40,10 +39,8 @@ public class RequestBuilder {
     public String getRedirectUrl(String path) {
         OAuthRequest request = this.constructGet(path, null);
         sign(request);
-        boolean presetVal = HttpURLConnection.getFollowRedirects();
-        HttpURLConnection.setFollowRedirects(false);
+        request.setFollowRedirects(false);
         Response response = request.send();
-        HttpURLConnection.setFollowRedirects(presetVal);
         if (response.getCode() == 301) {
             return response.getHeader("Location");
         } else {


### PR DESCRIPTION
When making an avatar request, or any request using `RequestBuilder#getRedirectUrl()`, we need to not follow any redirects, since the response of `getRedirectUrl()` is the `Location` of the redirect. Previously, we accomplished this via `HttpURLConnection#setFollowRedirects()`. However, this sets it globally, for any callers of `HttpURLConnection`.

We attempted to have our don't-follow-redirects requirement not affect any other callers by setting it back to its original value after making the request. However, this is not thread-safe. This pull request makes it so that we only change whether redirects are followed for this instance of `HttpURLConnection` by instead using `OAuthRequest#setFollowRedirects()`, which calls `HttpURLConnection#setInstanceFollowRedirects()` internally.

The requisite method was only added as of Scribe 1.3.5, so we also needed upgrade the dependency. 1.3.7 is the latest version on the 1.x tree, and there weren't many changes between 1.3.5 and 1.3.7, so we decided to use 1.3.7 instead. I know #83 will obsolete this version upgrade, but just adding it in for now to fix this bug.

cc @ericleong @KevinTCoughlin @bdenney 