### PR TITLE
Add missing or invalid javadoc

### DIFF
--- a/src/main/java/com/tumblr/jumblr/JumblrClient.java
+++ b/src/main/java/com/tumblr/jumblr/JumblrClient.java
@@ -99,6 +99,7 @@ public class JumblrClient {
 
     /**
      * Get the blogs the given user is following
+     * @param options the options
      * @return a List of blogs
      */
     public List<Blog> userFollowing(Map<String, ?> options) {
@@ -141,6 +142,7 @@ public class JumblrClient {
     /**
      * Get the followers for a given blog
      * @param blogName the name of the blog
+     * @param options the options for this call (or null)
      * @return the blog object for this blog
      */
     public List<User> blogFollowers(String blogName, Map<String, ?> options) {
@@ -335,6 +337,7 @@ public class JumblrClient {
      * @param postId the id of the post
      * @param reblogKey the reblog_key of the post
      * @param options Additional options (or null)
+     * @return The created reblog Post or null
      */
     public Post postReblog(String blogName, Long postId, String reblogKey, Map<String, ?> options) {
         if (options == null) {
@@ -347,6 +350,13 @@ public class JumblrClient {
         return this.blogPost(blogName, reblogId);
     }
 
+    /**
+     * Reblog a given post
+     * @param blogName the name of the blog to post to
+     * @param postId the id of the post
+     * @param reblogKey the reblog_key of the post
+     * @return The created reblog Post or null
+     */
     public Post postReblog(String blogName, Long postId, String reblogKey) {
         return this.postReblog(blogName, postId, reblogKey, null);
     }
@@ -356,6 +366,7 @@ public class JumblrClient {
      * @param blogName The blog name of the post
      * @param id the Post id
      * @param detail The detail to save
+     * @throws IOException if any file specified in detail cannot be read
      */
     public void postEdit(String blogName, Long id, Map<String, ?> detail) throws IOException {
         Map<String, Object> sdetail = JumblrClient.safeOptionMap(detail);
@@ -367,6 +378,8 @@ public class JumblrClient {
      * Create a post
      * @param blogName The blog name for the post
      * @param detail the detail to save
+     * @return Long the created post's id
+     * @throws IOException if any file specified in detail cannot be read
      */
     public Long postCreate(String blogName, Map<String, ?> detail) throws IOException {
         return requestBuilder.postMultipart(JumblrClient.blogPath(blogName, "/post"), detail).getId();
@@ -376,7 +389,10 @@ public class JumblrClient {
      * Set up a new post of a given type
      * @param blogName the name of the blog for this post (or null)
      * @param klass the type of Post to instantiate
+     * @param <T> the type of Post to instantiate
      * @return the new post with the client set
+     * @throws IllegalAccessException if class instantiation fails
+     * @throws InstantiationException if class instantiation fails
      */
     public <T extends Post> T newPost(String blogName, Class<T> klass) throws IllegalAccessException, InstantiationException {
         T post = klass.newInstance();

--- a/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
+++ b/src/main/java/com/tumblr/jumblr/exceptions/JumblrException.java
@@ -61,7 +61,7 @@ public class JumblrException extends RuntimeException {
 
     /**
      * Get the errors returned from the API
-     * @return List<String> errors (or null if none)
+     * @return the errors (or null if none)
      */
     public List<String> getErrors() {
         return this.errors;

--- a/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/AnswerPost.java
@@ -49,7 +49,7 @@ public class AnswerPost extends Post {
 
     /**
      * AnswerPost can not be saved
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException always throws this exception
      */
     @Override
     public void save() {

--- a/src/main/java/com/tumblr/jumblr/types/Blog.java
+++ b/src/main/java/com/tumblr/jumblr/types/Blog.java
@@ -197,7 +197,10 @@ public class Blog extends Resource {
     /**
      * Create a new post of a given type for this blog
      * @param klass the class of the post to make
+     * @param <T> the class of the post to make
      * @return new post
+     * @throws IllegalAccessException if class instantiation fails
+     * @throws InstantiationException if class instantiation fails
      */
     public <T extends Post> T newPost(Class<T> klass) throws IllegalAccessException, InstantiationException {
         return client.newPost(name, klass);

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -352,6 +352,7 @@ public class Post extends Resource {
 
     /**
      * Set the slug
+     * @param slug the post url slug
      */
     public void setSlug(String slug) {
         this.slug = slug;
@@ -385,6 +386,7 @@ public class Post extends Resource {
 
     /**
      * Set the tags for this post
+     * @param tags the tags
      */
     public void setTags(List<String> tags) {
         this.tags = tags;
@@ -392,6 +394,7 @@ public class Post extends Resource {
 
     /**
      * Add a tag
+     * @param tag the tag
      */
     public void addTag(String tag) {
         if (this.tags == null) {
@@ -402,6 +405,7 @@ public class Post extends Resource {
 
     /**
      * Remove a tag
+     * @param tag the tag
      */
     public void removeTag(String tag) {
         this.tags.remove(tag);
@@ -409,6 +413,7 @@ public class Post extends Resource {
 
     /**
      * Save this post
+     * @throws IOException if a file in detail cannot be read
      */
     public void save() throws IOException {
         if (id == null) {

--- a/src/main/java/com/tumblr/jumblr/types/Post.java
+++ b/src/main/java/com/tumblr/jumblr/types/Post.java
@@ -124,7 +124,7 @@ public class Post extends Resource {
 
     /**
      * Get the current state for this post
-     * @return the state
+     * @return the state; if set, one of `published`, `queued`, `draft`, or `private`
      */
     public String getState() {
         return state;
@@ -378,7 +378,8 @@ public class Post extends Resource {
 
     /**
      * Set the state for this post
-     * @param state the state
+     * @param state the state; one of `published`, `queued`, `draft`, or `private`.
+     *  Tumblr API defaults to `published` if not specified.
      */
     public void setState(String state) {
         this.state = state;

--- a/src/main/java/com/tumblr/jumblr/types/VideoPost.java
+++ b/src/main/java/com/tumblr/jumblr/types/VideoPost.java
@@ -20,6 +20,7 @@ public class VideoPost extends Post {
 
     /**
      * Get the permalink URL for this video
+     * @return the permalink url
      */
     public String getPermalinkUrl() {
         return permalink_url;


### PR DESCRIPTION
### Description

There were a number of places where warnings were showing up due to missing or invalid javadoc. Fix all of them.

Note that this does not add any _new_ javadoc, only fixes existing ones that were triggering warnings.

Add javadoc explaining values used by `Post.setState()` and `Post.getState()`. No validation added since it would be a breaking API change, and the API accepts these options liberally.

Fixes #110.

### Testing

Make sure there are no typos.