### PR TITLE
Fix avatar exceptions on 302 redirect responses

### DIFF
--- a/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
+++ b/src/main/java/com/tumblr/jumblr/request/RequestBuilder.java
@@ -44,7 +44,7 @@ public class RequestBuilder {
         HttpURLConnection.setFollowRedirects(false);
         Response response = request.send();
         HttpURLConnection.setFollowRedirects(presetVal);
-        if (response.getCode() == 301) {
+        if (response.getCode() == 301 || response.getCode() == 302) {
             return response.getHeader("Location");
         } else {
             throw new JumblrException(response);


### PR DESCRIPTION
### Description

Only a 301 response code was interpreted as a redirect, but the Tumblr API backend now returns 302s for avatar responses, triggering an exception being thrown when `JumblrClient.blogAvatar()` or `Blog.avatar()` is called.

Accept 302 redirects the same as 301 redirects.

Fixes #114

### Testing

```
master
client.blogAvatar("staff")
> Exception in thread "main" com.tumblr.jumblr.exceptions.JumblrException: Found

branch
client.blogAvatar("staff")
> https://78.media.tumblr.com/avatar_4490c797e72f_64.png#_=_
```

No unit tests added due to refactoring that would be necessary to add them.