### PR TITLE
Fix travis builds due to unavailable JDK versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: java
 
 jdk:
   - openjdk7
+  - openjdk8
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
+
 jdk:
-  - oraclejdk7
-  - openjdk6
   - openjdk7


### PR DESCRIPTION
### Description

Travis no longer includes oraclejdk7 or openjdk6, so don't try to build them. This was triggering build failures for all PRs since they've been removed. We will no longer be testing jdk6, but it has already been long unsupported.

Also add openjdk8 and oraclejdk8 builds.

See: https://github.com/travis-ci/travis-ci/issues/7884

### Testing

Make sure the builds pass.